### PR TITLE
update vagrantfile to current standards

### DIFF
--- a/config/minion
+++ b/config/minion
@@ -1,4 +1,4 @@
-master: 192.168.50.4
+master: 192.168.56.4
 startup_states: highstate
 multiprocessing: false
 


### PR DESCRIPTION
* Update network to .56 from .50 to match Vagrant defaults
* Remove centos 6 support
* Set default to Alma Linux 9
* Remove windows vm support, never did get anything working with it, and there are no current windows box's that I trust
* Add automatic `make` on vagrant up